### PR TITLE
issue-6470 introduce ConfigurationChangedHandler

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -60,6 +60,7 @@ import de.danoeh.antennapod.net.download.serviceinterface.DownloadServiceInterfa
 import de.danoeh.antennapod.playback.cast.CastEnabledActivity;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.ui.appstartintent.MainActivityStarter;
+import de.danoeh.antennapod.ui.common.ConfigurationChangedHandler;
 import de.danoeh.antennapod.ui.common.ThemeUtils;
 import de.danoeh.antennapod.ui.home.HomeFragment;
 import de.danoeh.antennapod.view.LockableBottomSheetBehavior;
@@ -457,7 +458,9 @@ public class MainActivity extends CastEnabledActivity {
         if (drawerToggle != null) { // Tablet layout does not have a drawer
             drawerToggle.onConfigurationChanged(newConfig);
         }
+
         setNavDrawerSize();
+        handleOnConfigurationChanged();
     }
 
     private void setNavDrawerSize() {
@@ -469,6 +472,15 @@ public class MainActivity extends CastEnabledActivity {
         int maxWidth = (int) getResources().getDimension(R.dimen.nav_drawer_max_screen_size);
 
         navDrawer.getLayoutParams().width = Math.min(width, maxWidth);
+    }
+
+    private void handleOnConfigurationChanged() {
+        FragmentManager fm = getSupportFragmentManager();
+        for (Fragment f: fm.getFragments()) {
+            if (f instanceof ConfigurationChangedHandler) {
+                ((ConfigurationChangedHandler) f).handleConfigurationChanged();
+            }
+        }
     }
 
     private int getScreenWidth() {

--- a/app/src/main/java/de/danoeh/antennapod/dialog/PlaybackControlsDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/PlaybackControlsDialog.java
@@ -14,9 +14,11 @@ import android.widget.CheckBox;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.core.util.playback.PlaybackController;
+import de.danoeh.antennapod.ui.common.ConfigurationChangedHandler;
+
 import java.util.List;
 
-public class PlaybackControlsDialog extends DialogFragment {
+public class PlaybackControlsDialog extends DialogFragment implements ConfigurationChangedHandler {
     private PlaybackController controller;
     private AlertDialog dialog;
 
@@ -86,5 +88,13 @@ public class PlaybackControlsDialog extends DialogFragment {
             controller.setAudioTrack((selectedAudioTrack + 1) % audioTracks.size());
             new Handler(Looper.getMainLooper()).postDelayed(this::setupAudioTracks, 500);
         });
+    }
+
+    @Override
+    public void handleConfigurationChanged() {
+        if (dialog != null) {
+            dialog.dismiss();
+            onCreateDialog(null).show();
+        }
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/dialog/PlaybackControlsDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/PlaybackControlsDialog.java
@@ -18,7 +18,7 @@ import de.danoeh.antennapod.ui.common.ConfigurationChangedHandler;
 
 import java.util.List;
 
-public class PlaybackControlsDialog extends DialogFragment implements ConfigurationChangedHandler {
+public class PlaybackControlsDialog extends DialogFragment {
     private PlaybackController controller;
     private AlertDialog dialog;
 
@@ -88,13 +88,5 @@ public class PlaybackControlsDialog extends DialogFragment implements Configurat
             controller.setAudioTrack((selectedAudioTrack + 1) % audioTracks.size());
             new Handler(Looper.getMainLooper()).postDelayed(this::setupAudioTracks, 500);
         });
-    }
-
-    @Override
-    public void handleConfigurationChanged() {
-        if (dialog != null) {
-            dialog.dismiss();
-            onCreateDialog(null).show();
-        }
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/dialog/PlaybackControlsDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/PlaybackControlsDialog.java
@@ -14,7 +14,6 @@ import android.widget.CheckBox;
 import de.danoeh.antennapod.R;
 import de.danoeh.antennapod.storage.preferences.UserPreferences;
 import de.danoeh.antennapod.core.util.playback.PlaybackController;
-import de.danoeh.antennapod.ui.common.ConfigurationChangedHandler;
 
 import java.util.List;
 

--- a/app/src/main/java/de/danoeh/antennapod/dialog/SleepTimerDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/SleepTimerDialog.java
@@ -14,6 +14,8 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
@@ -31,14 +33,17 @@ import de.danoeh.antennapod.core.service.playback.PlaybackService;
 import de.danoeh.antennapod.core.util.Converter;
 import de.danoeh.antennapod.core.util.playback.PlaybackController;
 import de.danoeh.antennapod.event.playback.SleepTimerUpdatedEvent;
+import de.danoeh.antennapod.ui.common.ConfigurationChangedHandler;
 
-public class SleepTimerDialog extends DialogFragment {
+public class SleepTimerDialog extends DialogFragment implements ConfigurationChangedHandler {
     private PlaybackController controller;
     private EditText etxtTime;
     private LinearLayout timeSetup;
     private LinearLayout timeDisplay;
     private TextView time;
     private CheckBox chAutoEnable;
+
+    private AlertDialog dialog = null;
 
     public SleepTimerDialog() {
 
@@ -103,8 +108,12 @@ public class SleepTimerDialog extends DialogFragment {
 
         etxtTime.setText(SleepTimerPreferences.lastTimerValue());
         etxtTime.postDelayed(() -> {
-            InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
-            imm.showSoftInput(etxtTime, InputMethodManager.SHOW_IMPLICIT);
+            Context context = getContext();
+            if (context != null) {
+                InputMethodManager imm = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+                imm.showSoftInput(etxtTime, InputMethodManager.SHOW_IMPLICIT);
+            } else {
+            }
         }, 100);
 
         final CheckBox cbShakeToReset = content.findViewById(R.id.cbShakeToReset);
@@ -131,7 +140,8 @@ public class SleepTimerDialog extends DialogFragment {
         changeTimesButton.setOnClickListener(changeTimesBtn -> {
             int from = SleepTimerPreferences.autoEnableFrom();
             int to = SleepTimerPreferences.autoEnableTo();
-            showTimeRangeDialog(getContext(), from, to);
+            Context context = getActivity();
+            showTimeRangeDialog(context, from, to);
         });
 
         Button disableButton = content.findViewById(R.id.disableSleeptimerButton);
@@ -161,7 +171,9 @@ public class SleepTimerDialog extends DialogFragment {
                 Snackbar.make(content, R.string.time_dialog_invalid_input, Snackbar.LENGTH_LONG).show();
             }
         });
-        return builder.create();
+
+        dialog = builder.create();
+        return dialog;
     }
 
     private void showTimeRangeDialog(Context context, int from, int to) {
@@ -207,5 +219,28 @@ public class SleepTimerDialog extends DialogFragment {
     private void closeKeyboard(View content) {
         InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Activity.INPUT_METHOD_SERVICE);
         imm.hideSoftInputFromWindow(content.getWindowToken(), 0);
+    }
+
+    @Override
+    public void handleConfigurationChanged() {
+        if (dialog != null) {
+            dialog.dismiss();
+            onCreateDialog(null).show();
+        }
+    }
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/dialog/SleepTimerDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/dialog/SleepTimerDialog.java
@@ -109,11 +109,8 @@ public class SleepTimerDialog extends DialogFragment implements ConfigurationCha
         etxtTime.setText(SleepTimerPreferences.lastTimerValue());
         etxtTime.postDelayed(() -> {
             Context context = getContext();
-            if (context != null) {
-                InputMethodManager imm = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
-                imm.showSoftInput(etxtTime, InputMethodManager.SHOW_IMPLICIT);
-            } else {
-            }
+            InputMethodManager imm = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+            imm.showSoftInput(etxtTime, InputMethodManager.SHOW_IMPLICIT);
         }, 100);
 
         final CheckBox cbShakeToReset = content.findViewById(R.id.cbShakeToReset);
@@ -140,8 +137,7 @@ public class SleepTimerDialog extends DialogFragment implements ConfigurationCha
         changeTimesButton.setOnClickListener(changeTimesBtn -> {
             int from = SleepTimerPreferences.autoEnableFrom();
             int to = SleepTimerPreferences.autoEnableTo();
-            Context context = getActivity();
-            showTimeRangeDialog(context, from, to);
+            showTimeRangeDialog(getContext(), from, to);
         });
 
         Button disableButton = content.findViewById(R.id.disableSleeptimerButton);
@@ -227,20 +223,5 @@ public class SleepTimerDialog extends DialogFragment implements ConfigurationCha
             dialog.dismiss();
             onCreateDialog(null).show();
         }
-    }
-
-    @Override
-    public void onAttach(@NonNull Context context) {
-        super.onAttach(context);
-    }
-
-    @Override
-    public void onDetach() {
-        super.onDetach();
-    }
-
-    @Override
-    public void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
@@ -581,14 +581,4 @@ public class AudioPlayerFragment extends Fragment implements
             }
         }
     }
-
-    @Override
-    public void onAttach(@NonNull Context context) {
-        super.onAttach(context);
-    }
-
-    @Override
-    public void onDetach() {
-        super.onDetach();
-    }
 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
@@ -1,5 +1,7 @@
 package de.danoeh.antennapod.fragment;
 
+import android.app.Dialog;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
@@ -569,9 +571,24 @@ public class AudioPlayerFragment extends Fragment implements
     @Override
     public void handleConfigurationChanged() {
         for (Fragment f : getChildFragmentManager().getFragments()) {
-            if (f instanceof ConfigurationChangedHandler) {
-                ((ConfigurationChangedHandler) f).handleConfigurationChanged();
+            if (f instanceof SleepTimerDialog) {
+                ((SleepTimerDialog) f).dismiss();
+                new SleepTimerDialog().show(getChildFragmentManager(), "SleepTimerDialog");
+            } else if (f instanceof PlaybackControlsDialog) {
+                ((PlaybackControlsDialog) f).dismiss();
+                PlaybackControlsDialog dialog = PlaybackControlsDialog.newInstance();
+                dialog.show(getChildFragmentManager(), "playback_controls");
             }
         }
+    }
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/AudioPlayerFragment.java
@@ -61,6 +61,7 @@ import de.danoeh.antennapod.dialog.SkipPreferenceDialog;
 import de.danoeh.antennapod.dialog.SleepTimerDialog;
 import de.danoeh.antennapod.dialog.VariableSpeedDialog;
 import de.danoeh.antennapod.menuhandler.FeedItemMenuHandler;
+import de.danoeh.antennapod.ui.common.ConfigurationChangedHandler;
 import de.danoeh.antennapod.ui.common.PlaybackSpeedIndicatorView;
 import de.danoeh.antennapod.view.ChapterSeekBar;
 import de.danoeh.antennapod.view.PlayButton;
@@ -73,7 +74,7 @@ import io.reactivex.schedulers.Schedulers;
  * Shows the audio player.
  */
 public class AudioPlayerFragment extends Fragment implements
-        ChapterSeekBar.OnSeekBarChangeListener, MaterialToolbar.OnMenuItemClickListener {
+        ChapterSeekBar.OnSeekBarChangeListener, MaterialToolbar.OnMenuItemClickListener, ConfigurationChangedHandler {
     public static final String TAG = "AudioPlayerFragment";
     public static final int POS_COVER = 0;
     public static final int POS_DESCRIPTION = 1;
@@ -563,5 +564,14 @@ public class AudioPlayerFragment extends Fragment implements
 
     public void scrollToPage(int page) {
         scrollToPage(page, false);
+    }
+
+    @Override
+    public void handleConfigurationChanged() {
+        for (Fragment f : getChildFragmentManager().getFragments()) {
+            if (f instanceof ConfigurationChangedHandler) {
+                ((ConfigurationChangedHandler) f).handleConfigurationChanged();
+            }
+        }
     }
 }

--- a/app/src/main/java/de/danoeh/antennapod/ui/home/HomeSectionsSettingsDialog.java
+++ b/app/src/main/java/de/danoeh/antennapod/ui/home/HomeSectionsSettingsDialog.java
@@ -4,13 +4,20 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.text.TextUtils;
+
+import androidx.appcompat.app.AlertDialog;
+
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import de.danoeh.antennapod.R;
 
 import java.util.List;
 
 public class HomeSectionsSettingsDialog {
-    public static void open(Context context, DialogInterface.OnClickListener onSettingsChanged) {
+    public static AlertDialog open(
+            Context context,
+            DialogInterface.OnClickListener onSettingsChanged,
+            DialogInterface.OnClickListener onDialogDismiss
+    ) {
         final List<String> hiddenSections = HomeFragment.getHiddenSections(context);
         String[] sectionLabels = context.getResources().getStringArray(R.array.home_section_titles);
         String[] sectionTags = context.getResources().getStringArray(R.array.home_section_tags);
@@ -36,7 +43,10 @@ public class HomeSectionsSettingsDialog {
             prefs.edit().putString(HomeFragment.PREF_HIDDEN_SECTIONS, TextUtils.join(",", hiddenSections)).apply();
             onSettingsChanged.onClick(dialog, which);
         });
-        builder.setNegativeButton(R.string.cancel_label, null);
-        builder.create().show();
+        builder.setNegativeButton(R.string.cancel_label, onDialogDismiss);
+        AlertDialog dialog = builder.create();
+        dialog.show();
+
+        return dialog;
     }
 }

--- a/ui/common/src/main/java/de/danoeh/antennapod/ui/common/ConfigurationChangedHandler.java
+++ b/ui/common/src/main/java/de/danoeh/antennapod/ui/common/ConfigurationChangedHandler.java
@@ -1,0 +1,5 @@
+package de.danoeh.antennapod.ui.common;
+
+public interface ConfigurationChangedHandler {
+    void handleConfigurationChanged();
+}

--- a/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/StatisticsFragment.java
+++ b/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/StatisticsFragment.java
@@ -20,6 +20,7 @@ import com.google.android.material.tabs.TabLayoutMediator;
 import de.danoeh.antennapod.core.dialog.ConfirmationDialog;
 import de.danoeh.antennapod.core.storage.DBWriter;
 import de.danoeh.antennapod.event.StatisticsEvent;
+import de.danoeh.antennapod.ui.common.ConfigurationChangedHandler;
 import de.danoeh.antennapod.ui.common.PagedToolbarFragment;
 import de.danoeh.antennapod.ui.statistics.downloads.DownloadStatisticsFragment;
 import de.danoeh.antennapod.ui.statistics.subscriptions.SubscriptionStatisticsFragment;
@@ -33,7 +34,7 @@ import org.greenrobot.eventbus.EventBus;
 /**
  * Displays the 'statistics' screen
  */
-public class StatisticsFragment extends PagedToolbarFragment {
+public class StatisticsFragment extends PagedToolbarFragment implements ConfigurationChangedHandler {
     public static final String TAG = "StatisticsFragment";
     public static final String PREF_NAME = "StatisticsActivityPrefs";
     public static final String PREF_INCLUDE_MARKED_PLAYED = "countAll";
@@ -145,6 +146,15 @@ public class StatisticsFragment extends PagedToolbarFragment {
         @Override
         public int getItemCount() {
             return TOTAL_COUNT;
+        }
+    }
+
+    @Override
+    public void handleConfigurationChanged() {
+        for (Fragment f : getChildFragmentManager().getFragments()) {
+            if (f instanceof ConfigurationChangedHandler) {
+                ((ConfigurationChangedHandler) f).handleConfigurationChanged();
+            }
         }
     }
 }

--- a/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/subscriptions/StatisticsFilterDialog.java
+++ b/ui/statistics/src/main/java/de/danoeh/antennapod/ui/statistics/subscriptions/StatisticsFilterDialog.java
@@ -1,5 +1,6 @@
 package de.danoeh.antennapod.ui.statistics.subscriptions;
 
+import android.app.Dialog;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.view.LayoutInflater;
@@ -37,7 +38,7 @@ public class StatisticsFilterDialog {
         filterDatesTo = makeMonthlyList(oldestDate, true);
     }
 
-    public void show() {
+    public Dialog show(Runnable postDialogAction) {
         StatisticsFilterDialogBinding dialogBinding = StatisticsFilterDialogBinding.inflate(
                 LayoutInflater.from(context));
         MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(context);
@@ -100,8 +101,17 @@ public class StatisticsFilterDialog {
                     .putLong(StatisticsFragment.PREF_FILTER_TO, timeFilterTo)
                     .apply();
             EventBus.getDefault().post(new StatisticsEvent());
+
+            postDialogAction.run();
         });
-        builder.show();
+
+        builder.setOnDismissListener((DialogInterface)-> {
+            postDialogAction.run();
+        });
+
+        Dialog result = builder.create();
+        result.show();
+        return result;
     }
 
     private Pair<String[], Long[]> makeMonthlyList(long oldestDate, boolean inclusive) {

--- a/ui/statistics/src/main/res/layout/statistics_filter_dialog.xml
+++ b/ui/statistics/src/main/res/layout/statistics_filter_dialog.xml
@@ -1,95 +1,99 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:padding="16dp">
-
-    <CheckBox
-        android:id="@+id/includeMarkedCheckbox"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/statistics_include_marked"
-        android:layout_marginBottom="8dp" />
-
+    android:layout_height="wrap_content">
     <LinearLayout
-        android:id="@+id/dateSelectionContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:padding="16dp">
 
-        <LinearLayout
+        <CheckBox
+            android:id="@+id/includeMarkedCheckbox"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:text="@string/statistics_include_marked"
+            android:layout_marginBottom="8dp" />
 
-            <TextView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:text="@string/statistics_from"
-                android:padding="4dp"
-                android:layout_weight="1" />
+        <LinearLayout
+            android:id="@+id/dateSelectionContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
-            <TextView
-                android:layout_width="0dp"
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/statistics_to"
-                android:padding="4dp"
-                android:layout_weight="1" />
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:text="@string/statistics_from"
+                    android:padding="4dp"
+                    android:layout_weight="1" />
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:text="@string/statistics_to"
+                    android:padding="4dp"
+                    android:layout_weight="1" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <Spinner
+                    android:id="@+id/timeFromSpinner"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1" />
+
+                <Spinner
+                    android:id="@+id/timeToSpinner"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/past_year_button"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:text="@string/statistics_filter_past_year"
+                    android:layout_weight="1"
+                    android:layout_marginEnd="4dp"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton" />
+
+                <Button
+                    android:id="@+id/allTimeButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:text="@string/statistics_filter_all_time"
+                    android:layout_weight="1"
+                    android:layout_marginStart="4dp"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton" />
+
+            </LinearLayout>
 
         </LinearLayout>
 
-        <LinearLayout
+        <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <Spinner
-                android:id="@+id/timeFromSpinner"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1" />
-
-            <Spinner
-                android:id="@+id/timeToSpinner"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1" />
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <Button
-                android:id="@+id/past_year_button"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:text="@string/statistics_filter_past_year"
-                android:layout_weight="1"
-                android:layout_marginEnd="4dp"
-                style="@style/Widget.MaterialComponents.Button.OutlinedButton" />
-
-            <Button
-                android:id="@+id/allTimeButton"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:text="@string/statistics_filter_all_time"
-                android:layout_weight="1"
-                android:layout_marginStart="4dp"
-                style="@style/Widget.MaterialComponents.Button.OutlinedButton" />
-
-        </LinearLayout>
+            android:text="@string/statistics_speed_not_counted"
+            android:layout_marginTop="16dp" />
 
     </LinearLayout>
-
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/statistics_speed_not_counted"
-        android:layout_marginTop="16dp" />
-
-</LinearLayout>
+</ScrollView>

--- a/ui/statistics/src/main/res/layout/statistics_filter_dialog.xml
+++ b/ui/statistics/src/main/res/layout/statistics_filter_dialog.xml
@@ -1,99 +1,95 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
-    <LinearLayout
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <CheckBox
+        android:id="@+id/includeMarkedCheckbox"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:padding="16dp">
+        android:text="@string/statistics_include_marked"
+        android:layout_marginBottom="8dp" />
 
-        <CheckBox
-            android:id="@+id/includeMarkedCheckbox"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/statistics_include_marked"
-            android:layout_marginBottom="8dp" />
+    <LinearLayout
+        android:id="@+id/dateSelectionContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
         <LinearLayout
-            android:id="@+id/dateSelectionContainer"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:orientation="horizontal">
 
-            <LinearLayout
-                android:layout_width="match_parent"
+            <TextView
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
+                android:text="@string/statistics_from"
+                android:padding="4dp"
+                android:layout_weight="1" />
 
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:text="@string/statistics_from"
-                    android:padding="4dp"
-                    android:layout_weight="1" />
-
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:text="@string/statistics_to"
-                    android:padding="4dp"
-                    android:layout_weight="1" />
-
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
+            <TextView
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
-
-                <Spinner
-                    android:id="@+id/timeFromSpinner"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1" />
-
-                <Spinner
-                    android:id="@+id/timeToSpinner"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1" />
-
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
-
-                <Button
-                    android:id="@+id/past_year_button"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:text="@string/statistics_filter_past_year"
-                    android:layout_weight="1"
-                    android:layout_marginEnd="4dp"
-                    style="@style/Widget.MaterialComponents.Button.OutlinedButton" />
-
-                <Button
-                    android:id="@+id/allTimeButton"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:text="@string/statistics_filter_all_time"
-                    android:layout_weight="1"
-                    android:layout_marginStart="4dp"
-                    style="@style/Widget.MaterialComponents.Button.OutlinedButton" />
-
-            </LinearLayout>
+                android:text="@string/statistics_to"
+                android:padding="4dp"
+                android:layout_weight="1" />
 
         </LinearLayout>
 
-        <TextView
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/statistics_speed_not_counted"
-            android:layout_marginTop="16dp" />
+            android:orientation="horizontal">
+
+            <Spinner
+                android:id="@+id/timeFromSpinner"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+            <Spinner
+                android:id="@+id/timeToSpinner"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/past_year_button"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="@string/statistics_filter_past_year"
+                android:layout_weight="1"
+                android:layout_marginEnd="4dp"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton" />
+
+            <Button
+                android:id="@+id/allTimeButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="@string/statistics_filter_all_time"
+                android:layout_weight="1"
+                android:layout_marginStart="4dp"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton" />
+
+        </LinearLayout>
 
     </LinearLayout>
-</ScrollView>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/statistics_speed_not_counted"
+        android:layout_marginTop="16dp" />
+
+</LinearLayout>


### PR DESCRIPTION
Fixes AntennaPod#6470

Screens/Dialogs covered:

1. StatisticsFilterDialog
![Screenshot_2023-08-13-21-49-40-74_32f26bc217f32ce640ab9d878b983871](https://github.com/braczkow/AntennaPod/assets/7397481/fa6e28f6-5e57-46ab-a975-36b4071ff9ce)

2. SleepTimerDialog
![Screenshot_2023-08-13-21-50-06-90_32f26bc217f32ce640ab9d878b983871](https://github.com/braczkow/AntennaPod/assets/7397481/d2a89eb4-2a65-4e1c-9531-42cb457d1244)

PlaybackControlsDialog
![Screenshot_2023-08-13-21-49-53-89_32f26bc217f32ce640ab9d878b983871](https://github.com/braczkow/AntennaPod/assets/7397481/5bfe6b1b-7d34-4e86-a9a1-3f02cee7e95c)


Please note that StatisticsFilterDialog and SleepTimerDialog do not scroll theirs content, so it's not fully usable. I plan to cover that in an another PR.

Technical details:
- this PR aims to deliver a callback (aka ConfigurationChangeHandler interface), triggered in MainActivity.onConfigurationChanged to anyone interested. 
- within the callback handler, one needs to recreate the dialog displayed, if any
- for "standard" Dialogs they just need to be recreated (aka: dismiss and show once again)
- for DialogFragments, it's the Fragment to be dismissed and shown again 

This might not be the most elegant solution, but given the constraint of not recreating literally anything upon a config change, it might be a reasonable one. :D 

Alternatives - one could allow for recreation of MainActivity and its child Fragments and use ViewModel to keep data available, but it's a *much* bigger change.
